### PR TITLE
Remove MD5 and SHA1

### DIFF
--- a/laikaboss/modules/explode_helloworld.py
+++ b/laikaboss/modules/explode_helloworld.py
@@ -142,7 +142,7 @@ class EXPLODE_HELLOWORLD(SI_MODULE):
                 # Take the module buffer and trim the first helloworld_param size bytes.
                 buff = buffer[helloworld_param:]
 
-                object_name = 'e_helloworld_%s_%s' % (len(buff), hashlib.md5(buff).hexdigest())
+                object_name = 'e_helloworld_%s_%s' % (len(buff), hashlib.sha512(buff).hexdigest()[0:32])
 
                 logging.debug('HELLOWORLD - New object: %s', object_name)
                 

--- a/laikaboss/modules/listcheck.py
+++ b/laikaboss/modules/listcheck.py
@@ -37,7 +37,7 @@ class LISTCHECK(SI_MODULE):
                 
             
             
-            if scanObject.objectHash in self.lists[args['list']]['list']['type']['md5']:
+            if scanObject.objectHash in self.lists[args['list']]['list']['type']['sha512']:
                 scanObject.addMetadata(self.module_name, 'list', args['list'])
                 scanObject.addFlag(self.lists[args['list']]['flagPrefix']+scanObject.objectHash)
                 

--- a/laikaboss/modules/listcheck.py
+++ b/laikaboss/modules/listcheck.py
@@ -37,7 +37,7 @@ class LISTCHECK(SI_MODULE):
                 
             
             
-            if scanObject.objectHash in self.lists[args['list']]['list']['type']['sha512']:
+            if scanObject.objectHash in self.lists[args['list']]['list']['type']['SHA512']:
                 scanObject.addMetadata(self.module_name, 'list', args['list'])
                 scanObject.addFlag(self.lists[args['list']]['flagPrefix']+scanObject.objectHash)
                 

--- a/laikaboss/modules/meta_hash.py
+++ b/laikaboss/modules/meta_hash.py
@@ -25,7 +25,7 @@ class META_HASH(SI_MODULE):
         #metaDict['SHA224'] = hashlib.sha224(scanObject.buffer).hexdigest()
         metaDict['SHA256'] = hashlib.sha256(scanObject.buffer).hexdigest()
         #metaDict['SHA384'] = hashlib.sha384(scanObject.buffer).hexdigest()
-        metaDict['SHA512'] = hashlib.sha512(scanObject.buffer).hexdigest()
+        metaDict['SHA512'] = hashlib.sha512(scanObject.buffer).hexdigest()[0:32]
         metaDict['ssdeep'] = ssdeep.hash(scanObject.buffer)
         scanObject.addMetadata(self.module_name, "HASHES", metaDict)
         return moduleResult

--- a/laikaboss/modules/meta_hash.py
+++ b/laikaboss/modules/meta_hash.py
@@ -22,14 +22,10 @@ class META_HASH(SI_MODULE):
     def _run(self, scanObject, result, depth, args):
         moduleResult = [] 
         metaDict = {}
-        metaDict['md5']    = hashlib.md5(scanObject.buffer).hexdigest()
-        metaDict['SHA1']   = hashlib.sha1(scanObject.buffer).hexdigest()
         #metaDict['SHA224'] = hashlib.sha224(scanObject.buffer).hexdigest()
         metaDict['SHA256'] = hashlib.sha256(scanObject.buffer).hexdigest()
         #metaDict['SHA384'] = hashlib.sha384(scanObject.buffer).hexdigest()
         metaDict['SHA512'] = hashlib.sha512(scanObject.buffer).hexdigest()
         metaDict['ssdeep'] = ssdeep.hash(scanObject.buffer)
-        
         scanObject.addMetadata(self.module_name, "HASHES", metaDict)
-        
         return moduleResult

--- a/laikaboss/modules/meta_pe.py
+++ b/laikaboss/modules/meta_pe.py
@@ -48,8 +48,8 @@ class META_PE(SI_MODULE):
                 secData = { 'Virtual Address' : '0x%08X' % section.VirtualAddress,
                             'Virtual Size' : section.Misc_VirtualSize,
                             'Raw Size' : section.SizeOfRawData,
-                            'MD5' : section.get_hash_md5() }
-                if secData['MD5'] != scanObject.objectHash: 
+                            'SHA512' : section.get_hash_sha512() }
+                if secData['SHA512'] != scanObject.objectHash: 
                     moduleResult.append(ModuleObject(buffer=section.get_data(), 
                                                      externalVars=ExternalVars(filename=secName)))
     

--- a/laikaboss/modules/meta_pe.py
+++ b/laikaboss/modules/meta_pe.py
@@ -289,6 +289,6 @@ class META_PE(SI_MODULE):
                 result['id'] = [x[0] for x in res]
                 result['version'] = [x[1] for x in res]
                 result['count'] = [x[2] for x in res]
-                result['hash'] = hashlib.md5(str(res)).hexdigest()
+                result['hash'] = hashlib.sha512(str(res)).hexdigest()[0:32]
 
         return result

--- a/laikaboss/util.py
+++ b/laikaboss/util.py
@@ -92,15 +92,15 @@ def listToSSV(alist):
 
 def getObjectHash(buffer):
     '''
-    Uses hashlib to get an md5 of the raw object buffer
+    Uses hashlib to get a truncated prefix hash from SHA512 of the raw object buffer
 
     Arguments:
     buffer -- raw object buffer
 
     Returns:
-    string containing the md5 digest of the buffer
+    string containing the truncated prefix hash from SHA512 digest of the buffer
     '''
-    return hashlib.md5(buffer).hexdigest()
+    return hashlib.sha512(buffer).hexdigest()[0:32]
 
 def log_result(result, returnOutput=False):
     '''


### PR DESCRIPTION
MD5 hash been broken since 2004 by Xiaoyun Wang and SHA1 is almost certainly going to be broken soon seeing as the latest cryptanalytic attack by a academic, Marc Stevens achieved a 76 round free start collision using GPU's.  These hashing algorithms should not be seen in security software that relies on signatures. Use SHA512, or SHA256 instead and if space is a issue, truncated SHA512 will suffice. Check out this recent post  http://blog.silentsignal.eu/2015/06/10/poisonous-md5-wolves-among-the-sheep/
