### PR TITLE
External Metadata Loading Changes/Fixes

### DIFF
--- a/cloudscan.py
+++ b/cloudscan.py
@@ -218,7 +218,11 @@ def main():
 
     if options.ext_metadata:
         try:
-            ext_metadata = json.loads(options.ext_metadata)
+            if os.path.exists(options.ext_metadata):
+              with open(options.ext_metadata) as metafile:
+                ext_metadata = json.loads(str(metafile.read()).replace("'","\""))
+            else:
+              ext_metadata = json.loads(options.ext_metadata)
             assert isinstance(ext_metadata, dict)
         except:
             print "External Metadata must be a dictionary!"

--- a/cloudscan.py
+++ b/cloudscan.py
@@ -219,10 +219,10 @@ def main():
     if options.ext_metadata:
         try:
             if os.path.exists(options.ext_metadata):
-              with open(options.ext_metadata) as metafile:
-                ext_metadata = json.loads(metafile.read())
+                with open(options.ext_metadata) as metafile:
+                    ext_metadata = json.loads(metafile.read())
             else:
-              ext_metadata = json.loads(options.ext_metadata)
+                ext_metadata = json.loads(options.ext_metadata)
             assert isinstance(ext_metadata, dict)
         except:
             print "External Metadata must be a dictionary!"

--- a/cloudscan.py
+++ b/cloudscan.py
@@ -220,7 +220,7 @@ def main():
         try:
             if os.path.exists(options.ext_metadata):
               with open(options.ext_metadata) as metafile:
-                ext_metadata = json.loads(str(metafile.read()).replace("'","\""))
+                ext_metadata = json.loads(metafile.read())
             else:
               ext_metadata = json.loads(options.ext_metadata)
             assert isinstance(ext_metadata, dict)

--- a/laika.py
+++ b/laika.py
@@ -31,6 +31,7 @@ from distutils.util import strtobool
 import zlib
 import json
 
+
 # Variable to store configs from file
 configs = {}
 

--- a/laika.py
+++ b/laika.py
@@ -29,6 +29,7 @@ from laikaboss.clientLib import getJSON, getRootObject, get_scanObjectUID
 from ast import literal_eval
 from distutils.util import strtobool
 import zlib
+import json
 
 # Variable to store configs from file
 configs = {}


### PR DESCRIPTION
Added json import for laika.py for external metadata load, calls were present, but never imported.  Also added cloudscan.py ability to pull meta data from file similar to that of laika.py.
