### PR TITLE
Fix laika.py runtime error due to older pefile included in Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -97,6 +97,9 @@ RUN pip install fluent-logger \
   py-unrar2 \
   ssdeep
 
+# fix error condition caused by older pefile in dockerbuild
+RUN pip install pefile --upgrade 
+
 # Add nonroot user, clone repo and setup environment
 RUN groupadd -r nonroot && \
   useradd -r -g nonroot -d /home/nonroot -s /sbin/nologin -c "Nonroot User" nonroot && \


### PR DESCRIPTION
Saw a closed issue related to a pefile induced runtime error when running laika.py. The included change to the Dockerfile updates pefile and when I run laikaboss now in a container created using the change, the error is no longer there.
