### PR TITLE
Resolve pefile Issue

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get -y install software-properties-common && \
   python-ipy \
   python-m2crypto \
   python-msgpack \
-  python-pefile \
   python-pexpect \
   python-pip \
   python-progressbar \
@@ -93,6 +92,7 @@ RUN cd /tmp && \
 RUN pip install fluent-logger \
   interruptingcow \
   olefile \
+  pefile \
   pylzma \
   py-unrar2 \
   ssdeep


### PR DESCRIPTION
Changelog:
- remove launchpad version of pefile (via apt repo)
- include newer version of pefile (via pip package manager)

I've also updated the Dockerfile on DockerHub (i.e. https://hub.docker.com/r/wzod/laikaboss/ ) to reflect the changes.
