### PR TITLE
digital signature explosion in meta_pe

### DIFF
--- a/laikaboss/modules/meta_pe.py
+++ b/laikaboss/modules/meta_pe.py
@@ -222,10 +222,10 @@ class META_PE(SI_MODULE):
                         scanObject.addMetadata(self.module_name, 'NB10', debug)
 
             # Extract digital signature
-            digi_sig_virtual_address = pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_SECURITY']].VirtualAddress
-            if digi_sig_virtual_address > 0:
+            digital_sig_virtual_address = pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_SECURITY']].VirtualAddress
+            if digital_sig_virtual_address > 0:
                 scanObject.addFlag('pe:nfo:signed')
-                signatureData = pe.write()[digi_sig_virtual_address + 8:];
+                signatureData = pe.write()[digital_sig_virtual_address + 8:]
                 if len(signatureData) > 0:
                     name = scanObject.filename + '_digital_signature'
                     moduleResult.append(ModuleObject(buffer=signatureData, externalVars=ExternalVars(filename=name)))

--- a/laikaboss/modules/meta_pe.py
+++ b/laikaboss/modules/meta_pe.py
@@ -221,6 +221,17 @@ class META_PE(SI_MODULE):
                         debug["pdb"] = pdb[8:].rstrip('\x00')
                         scanObject.addMetadata(self.module_name, 'NB10', debug)
 
+            # Extract digital signature
+            digi_sig_virtual_address = pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_SECURITY']].VirtualAddress
+            if digi_sig_virtual_address > 0:
+                scanObject.addFlag('pe:nfo:signed')
+                signatureData = pe.write()[digi_sig_virtual_address + 8:];
+                if len(signatureData) > 0:
+                    name = scanObject.filename + '_digital_signature'
+                    moduleResult.append(ModuleObject(buffer=signatureData, externalVars=ExternalVars(filename=name)))
+                else:
+                    scanObject.addFlag('pe:nfo:empty_signature')
+
         except pefile.PEFormatError:
             logging.debug("Invalid PE format")
         return moduleResult


### PR DESCRIPTION
This PR adds digital signature explosion to the META_PE module. I tried to be mindful of what additional information would be useful to analysts, so I included the two flags that are triggered when there is virtual address space for the digital signature and when the digital signature data is empty. 

Something to consider would be the filename of the exploded digital signature. This currently just takes whatever the PE filename is and appends '_digital_signature' ... that might be good enough, but if there's a better idea, I'm happy to try it out.
