### PR TITLE
Add support for compiling from a string.

### DIFF
--- a/laikaboss/util.py
+++ b/laikaboss/util.py
@@ -66,7 +66,7 @@ def compile_rule(rule, externalVars={}):
     except Exception as e:
         logging.debug("util: compiling from string source failed: %s" % str(e))
 
-    return None
+    raise Exception('Unable to compile rules.')
 
 def clear_yara_on_demand(rule):
     try:
@@ -77,15 +77,11 @@ def clear_yara_on_demand(rule):
 def yara_on_demand(rule, theBuffer, externalVars={}, maxBytes=0):
     logging.debug("util: doing on demand yara scan")
     logging.debug("util: externalVars: %s" % str(externalVars))
-    if rule not in yara_on_demand_rules:
-        result = compile_rule(rule, externalVars=externalVars)
-        if result is not None:
-            yara_on_demand_rules[rule] = result
-        else:
-            logging.exception("util: yara on demand scan failed")
-            return []
-
     try:
+        if rule not in yara_on_demand_rules:
+            result = compile_rule(rule, externalVars=externalVars)
+            yara_on_demand_rules[rule] = result
+
         if maxBytes and len(theBuffer) > maxBytes:
             matches = yara_on_demand_rules[rule].match(data=buffer(theBuffer, 0, maxBytes) or 'EMPTY', externals=externalVars)
         else:

--- a/laikaboss/util.py
+++ b/laikaboss/util.py
@@ -78,7 +78,12 @@ def yara_on_demand(rule, theBuffer, externalVars={}, maxBytes=0):
     logging.debug("util: doing on demand yara scan")
     logging.debug("util: externalVars: %s" % str(externalVars))
     if rule not in yara_on_demand_rules:
-        yara_on_demand_rules[rule] = compile_rule(rule, externalVars=externalVars)
+        result = compile_rule(rule, externalVars=externalVars)
+        if result is not None:
+            yara_on_demand_rules[rule] = result
+        else:
+            logging.exception("util: yara on demand scan failed")
+            return []
 
     try:
         if maxBytes and len(theBuffer) > maxBytes:


### PR DESCRIPTION
Also, add support for clearing YARA rules from the cached set.

Note that in order to not pollute the logs when compiling from a string I have snipped log messages a bit. Also, apologies for all the whitespace fixes in here but we are sticklers for this kind of stuff, so much so that it's in everyone's editor to clean it up by default. I'm happy to remove all the whitespace fixes if you want, but I think it will be good to make the code whitespace clean over time.
