### PR TITLE
New Explode Module: EXPLODE_VBA

### DIFF
--- a/laikaboss/modules/explode_vba.py
+++ b/laikaboss/modules/explode_vba.py
@@ -1,0 +1,92 @@
+# Copyright 2017 Kemp Langhorne
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+from laikaboss.si_module import SI_MODULE
+from laikaboss.objectmodel import ModuleObject, ExternalVars, QuitScanException, \
+                                GlobalScanTimeoutError, GlobalModuleTimeoutError
+from laikaboss.util import log_module
+from oletools import olevba
+
+class EXPLODE_VBA(SI_MODULE):
+    '''
+    Version: 0.50
+
+    Input: Any supported format listed at https://bitbucket.org/decalage/oletools/wiki/olevba
+
+    Output: Extracted and decompressed VBA objects (macro and forms).  Module also adds basic metadata about the object when possible. 
+
+    Purpose: Uses olevba from oletools to extract embedded VBA macro and forms in various types of documents.
+
+    Note 1: olevba has many other features beyond just macro extraction. This module does only extraction.
+    Note 2: Test olevba.py (from decalage) against a known sample to verify you have decalage tools installed correctly 
+
+    Example JSON output:
+
+        "EXPLODE_VBA": {
+          "Parsed_Macros_Metadata": [
+            {
+              "VBA_project": [
+                "('', 'PROJECT', 'VBA/dir')"
+              ],
+              "OLE_stream": "VBA/Z1",
+              "Type": "OLE",
+              "VBA_filename": "Z1.bas"
+            }
+          ],
+          "VBA_Forms_Found_Streams": [
+            "sTVOL/o"
+          ]
+
+    Example of exploded file naming:
+        e_vba_a2a729ef454c64cd44377c2703f4222e_sTVOL.frm           -> This is a macro
+        e_vba_a2a729ef454c64cd44377c2703f4222e_A0.bas              -> This is a macro
+        e_vba_a2a729ef454c64cd44377c2703f4222e_combined_forms.txt  -> This is a form
+
+
+   '''
+
+    def __init__(self,):
+        self.module_name = "EXPLODE_VBA"
+
+    def _run(self, scanObject, result, depth, args):
+        moduleResult = []
+        try:
+            vbaparser = olevba.VBA_Parser(scanObject.objectHash, data=scanObject.buffer) #load ole into olevba    
+            if vbaparser.detect_vba_macros(): #VBA Macro Found
+                # Loop to parse VBA Macro
+                for (filename, stream_path, vba_filename, vba_code) in vbaparser.extract_macros(): # macro extraction
+                    macrofilesdict = {}
+                    macrofilesdict.update({'Type': vbaparser.type, 'VBA_project': vbaparser.vba_projects, 'OLE_stream': stream_path, 'VBA_filename': vba_filename})
+                    scanObject.addMetadata(self.module_name, "Parsed_Macros_Metadata", macrofilesdict)
+                    explodevbafilename = 'e_vba_%s_%s' % (scanObject.objectHash, vba_filename) # Exploded file name contains source hash
+                    moduleResult.append(ModuleObject(buffer=vba_code, externalVars=ExternalVars(filename=explodevbafilename)))
+                # Loop to parse VBA Forms
+                combinedstring = ""
+                formfilesdlist = set()
+                for (filename, stream_path, form_string) in vbaparser.extract_form_strings():
+                    formfilesdlist.add(stream_path) #set because stream_path could be the same over and over again
+                    combinedstring += " %s" % form_string #combining all found forms text into a single variable
+                if combinedstring: #form text found
+                    scanObject.addMetadata(self.module_name, "VBA_Forms_Found_Streams", formfilesdlist)
+                    explodeformsfilename = 'e_vba_%s_combined_forms.txt' % (scanObject.objectHash)
+                    moduleResult.append(ModuleObject(buffer=combinedstring, externalVars=ExternalVars(filename=explodeformsfilename)))
+            vbaparser.close()       
+
+        except olevba.OlevbaBaseException as e:  # exceptions from olevba import will raise
+            olevbaerror = 'e_vba:err:%s' % e
+            #scanObject.addFlag(olevbaerror)
+            log_module("MSG", self.module_name, 0, scanObject, result, olevbaerror)
+        except (QuitScanException, GlobalScanTimeoutError, GlobalModuleTimeoutError):
+            raise
+        return moduleResult


### PR DESCRIPTION
Note: jshlbrd also has a pull request for a module that does VBA extraction. My module **in addition** does file extraction (explode) and metadata for forms. Otherwise, they are similar. 

explode_vba.py is a scanning module to explode the VBA inside objects. It uses olevba from decalage's oletools to perform the object extraction.

Quick note: Olevba has some object explosion built into the code. For example, it can look inside DOCX files for VBA. I tried to stay away from explosions done inside the decalage code and instead rely on Laika BOSS for explosion. To continue with the previous example, Laika BOSS will explode the ZIP and then this module will pick up the compressed VBA object and extract the macro from it.

Input are OLE document files and output is metadata and extracted objects. Most supported formats listed at https://bitbucket.org/decalage/oletools/wiki/olevba which use olevba's VBA_Parser module willw work as long as it is also configured in dispatch.yara

Here are my notes added to decalage's "Supported formats" 

- Word 97-2003 (.doc, .dot) -> Will work
- Word 2007+ (.docm, .dotm) -> Note: Will rely on Laika BOSS explosion of ZIP
- Word 2003 XML (.xml)      -> Will work
- Word/Excel MHTML, aka Single File Web Page (.mht)  -> Will work.
- Excel 97-2003 (.xls)      -> Will work
- Excel 2007+ (.xlsm, .xlsb) -> Should work and needs to be tested.
- PowerPoint 2007+ (.pptm, .ppsm) -> Note: Not currently supported. Will most likely need to be a seperate Laika BOSS module.
- Text file containing VBA or VBScript source code -> Should work and needs to be tested. Needs dispatch.yara addition to run EXPLODE_VBA against all files since txt files have no file magic to key on.

Output: Extracted and decompressed VBA objects (macro and forms). Module also adds basic metadata about the object when possible.

Below I use a Office 2007 Word sample (zip). I run olevba against the file which uses its native exploding code and shows that there are macros and forms. I then show the scan output from EXPLODE_VBA which shows the collected metadata. This is followed by examples of the actual extracted files.

By running the EXPLODE_VBA module in conjuction with EXPLODE_ZIP and EXPLODE_OLE, the macros are successfully extracted.
```
[user@localhost laikaboss]# file mysample.docx

mysample.docx: Microsoft Word 2007+
[user@localhost laikaboss]# hexdump -Cv mysample.docx | head
00000000  50 4b 03 04 14 00 06 00  08 00 00 00 21 00 84 98  |PK..........!...|
00000010  01 20 94 01 00 00 2a 06  00 00 13 00 08 02 5b 43  |. ....*.......[C|
00000020  6f 6e 74 65 6e 74 5f 54  79 70 65 73 5d 2e 78 6d  |ontent_Types].xm|
```

```
[user@localhost laikaboss]# olevba -a mysample.docx
olevba 0.50 - http://decalage.info/python/oletools
Flags        Filename
-----------  -----------------------------------------------------------------
OpX:MASIHB-- mysample.docx
===============================================================================
FILE: mysample.docx
Type: OpenXML
-------------------------------------------------------------------------------
VBA MACRO Dard.cls
in file: word/vbaProject.bin - OLE stream: u'VBA/Dard'
-------------------------------------------------------------------------------
VBA MACRO sTVOL.frm
in file: word/vbaProject.bin - OLE stream: u'VBA/sTVOL'
-------------------------------------------------------------------------------
VBA MACRO A0.bas
in file: word/vbaProject.bin - OLE stream: u'VBA/A0'
-------------------------------------------------------------------------------
VBA MACRO Ishimitsu.cls
in file: word/vbaProject.bin - OLE stream: u'VBA/Ishimitsu'
-------------------------------------------------------------------------------
VBA MACRO Module1.bas
in file: word/vbaProject.bin - OLE stream: u'VBA/Module1'
-------------------------------------------------------------------------------
VBA MACRO Module2.bas
in file: word/vbaProject.bin - OLE stream: u'VBA/Module2'
-------------------------------------------------------------------------------
VBA MACRO Class1.cls
in file: word/vbaProject.bin - OLE stream: u'VBA/Class1'
-------------------------------------------------------------------------------
VBA MACRO Z1.bas
in file: word/vbaProject.bin - OLE stream: u'VBA/Z1'
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
▒rundll32.exe
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
▒http://
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma/
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
setRequestHeader
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Microsoft.XMLHTTPPPAPAdodb.streaMPPAPshell.ApplicationPPAPWscript.shellPPAPProcessPPAPGeTPPAPTeMPPPAPTypePPAPopenPPAPwritePPAPresponseBodyPPAPsavetofilePPAP\shubert.aza
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
hoOptionButton1der
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
hoSend
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
ratatu
-------------------------------------------------------------------------------
VBA FORM STRING IN 'word/vbaProject.bin' - OLE stream: u'sTVOL/o'
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Tahoma
```


-> Metadata  collected from Module
```
        "EXPLODE_VBA": {
          "Parsed_Macros_Metadata": [
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Dard",
              "Type": "OLE",
              "VBA_filename": "Dard.cls"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/sTVOL",
              "Type": "OLE",
              "VBA_filename": "sTVOL.frm"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/A0",
              "Type": "OLE",
              "VBA_filename": "A0.bas"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Ishimitsu",
              "Type": "OLE",
              "VBA_filename": "Ishimitsu.cls"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Module1",
              "Type": "OLE",
              "VBA_filename": "Module1.bas"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Module2",
              "Type": "OLE",
              "VBA_filename": "Module2.bas"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Class1",
              "Type": "OLE",
              "VBA_filename": "Class1.cls"
            },
            {
              "VBA_project": [
                "('', 'PROJECT', 'VBA/dir')"
              ],
              "OLE_stream": "VBA/Z1",
              "Type": "OLE",
              "VBA_filename": "Z1.bas"
            }
          ],
          "VBA_Forms_Found_Streams": [
            "sTVOL/o"
          ]
```



-> Showing the files exploded and their filenames
```
[user@localhost laikaboss]# ls -lart ~/EXPLODED/0bf5e6c6-0dad-404c-a69e-30bf4a9962ce/ | grep e_vba
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Z1.bas
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Module2.bas
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Dard.cls
e_vba_6b35ca7ccdf6a2221cacab994faa4349_A0.bas
e_vba_6b35ca7ccdf6a2221cacab994faa4349_sTVOL.frm
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Ishimitsu.cls
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Module1.bas
e_vba_6b35ca7ccdf6a2221cacab994faa4349_combined_forms.txt
e_vba_6b35ca7ccdf6a2221cacab994faa4349_Class1.cls
```

Dispatch.yara change to make this module run against OLEs, Word2003 XML, and MHTML.
```
rule type_is_msoffice2003
{
    meta:
        scan_modules = "EXPLODE_OLE(minFileSize=128) EXPLODE_VBA"
        file_type = "ole"
    strings:
        $a = { D0 CF 11 E0 A1 B1 1A E1 }
    condition:
        $a at 0
}

rule type_is_msoffice2003xml
{
    meta:
        scan_modules = "EXPLODE_VBA"
        file_type = "xml"
    strings:
       $a = { 3c 3f 78 6d 6c 20 76 65 72 73 69 6f 6e 3d } //<?xml version=        
       $b = "http://schemas.microsoft.com/office/word/2003/wordml"
    condition:
        $a at 0 and $b
}

rule type_is_msofficemhtml
{
    meta:
        scan_modules = "EXPLODE_VBA"
        file_type = "mhtml"
    strings:
        $a = "MIME-Version: 1.0"
        $b = "This document is a Single File Web Page, also known as a Web Archive file"
    condition:
        $a at 0 and $b
}
```